### PR TITLE
头部状态栏-clock、进度条、标题的调整与优化

### DIFF
--- a/codesource-vue/src/App.vue
+++ b/codesource-vue/src/App.vue
@@ -46,7 +46,7 @@ export default {
       asideDisplayBool: false,
 
       //全局进度
-      golballine:10,
+      golballine:68,
 
       headStyle: {
         gap: '10px', /* 子元素之间的间距 */
@@ -57,7 +57,7 @@ export default {
         left: '0px',
         right: '0px',
         top: '0px',
-        height: '67px',
+        height: '65px',
         borderBottom: '0.4px solid #c8c8c8',/* 黑色的2像素描边 */
         position: 'fixed'
       },

--- a/codesource-vue/src/components/HeadDisplay.vue
+++ b/codesource-vue/src/components/HeadDisplay.vue
@@ -1,9 +1,10 @@
 <template>
     <div id="Head">
-        <button id="projectName">
+        <show-time></show-time>
+        <el-button id="projectName">
             project name
-        </button>
-        <button id="pieChartButton">
+        </el-button>
+        <el-button id="pieChartButton">
             <el-progress
                 type="circle"
                 :percentage="inlong"
@@ -11,18 +12,22 @@
                 :width="50"
                 :color="customColors"
             />
-        </button>
-        <Botton-list id="bottonlist"></Botton-list>
-        <show-time></show-time>
+        </el-button>
+        <!-- <Botton-list id="bottonlist"></Botton-list>，注释掉了原先的按钮列表 -->
+        <UserAvatar id="useravatar"></UserAvatar>
+        <PageMenu id="pagemenu"></PageMenu>
         <!-- 临时隐藏了原有的进度条 -->
         <progress-bar-main v-if="false" id="progress" :stroke-width="80" :Linelong="inlong"></progress-bar-main>
     </div>
 </template>
 
 <script>
-import BottonList from './HeaddisplayComponents/BottonList.vue';
+// import BottonList from './HeaddisplayComponents/BottonList.vue';
 import ShowTime from './HeaddisplayComponents/ShowTime.vue';
-import ProgressBarMain from './ProgressBarMain.vue';
+// import ProgressBarMain from './ProgressBarMain.vue';
+import PageMenu from './HeaddisplayComponents/PageMenu.vue';
+import UserAvatar from './HeaddisplayComponents/UserAvatar.vue';
+
 
 export default{
     data(){
@@ -38,10 +43,12 @@ export default{
         }
     },
     components:{
-        BottonList,
-        ShowTime,
-        ProgressBarMain,
-    },
+    // BottonList,
+    ShowTime,
+    // ProgressBarMain,
+    PageMenu,
+    UserAvatar,
+},
     props:{
         inlong:Number
     }
@@ -69,6 +76,8 @@ export default{
     -webkit-user-select: none; /* 适用于谷歌浏览器和Safari */ -moz-user-select: none; /* 适用于火狐浏览器 */ -ms-user-select: none; /* 适用于Internet Explorer/Edge */ user-select: none; /* 适用于支持CSS3的浏览器 */
     position: absolute;
     top: 50%; 
+    padding: 0%;
+    margin: 0%;
     transform: translateY(-50%); 
 }
 
@@ -80,11 +89,12 @@ export default{
     user-select: none; /* 适用于支持CSS3的浏览器 */
     position: fixed; 
     top: 0px;
-    left: calc(65%); /* 紧挨着 projectName 右侧 */
+    left: calc(64.2%); /* 紧挨着 projectName 右侧 */
     text-align: center; 
-    height: 65px;
+    height: 62px;
+    width: 62px;
+    margin-bottom: 3px;
     z-index: 1000; 
-
     /* 按钮样式 */
     color: #484848; 
 
@@ -95,12 +105,12 @@ export default{
     border: none; /* 移除边框 */
     box-shadow: none; /* 移除阴影 */
     outline: none; /* 移除点击时的轮廓 */
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
 }
 
 #pieChartButton:hover {
     transform: translateY(2px); /* 悬浮时略微下凹 */
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* 悬浮时添加阴影 */
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1); /* 悬浮时添加阴影 */
 }
 
 #pieChartButton:active {
@@ -118,7 +128,8 @@ export default{
     transform: translateX(-50%); /* 通过偏移实现精确居中 */
     text-align: center; /* 文本居中 */
     width: 30%; /* 宽度根据内容自适应 */
-    height: 65px;
+    height: 62px;
+    margin-bottom: 3px;
     z-index: 1000; /* 确保元素在最上层 */
 
     /* 按钮样式 */
@@ -134,18 +145,34 @@ export default{
     border: none; /* 移除边框 */
     box-shadow: none; /* 移除阴影 */
     outline: none; /* 移除点击时的轮廓 */
-    transition: transform 0.2s ease, box-shadow 0.2s ease; /*缓动效果*/
+    transition: transform 0.1s ease, box-shadow 0.1s ease; /*缓动效果*/
 }
 
 #projectName:hover {
     transform: translateX(-50%) translateY(2px); /* 悬浮时略微下凹 */
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* 悬浮时添加阴影 */
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1); /* 悬浮时添加阴影 */
 }
 
 #projectName:active {
     transform: translateX(-50%) translateY(4px); /* 点击时进一步下凹 */
     color: #303030; /* 点击时颜色加深 */
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); /* 点击时阴影变小 */
+}
+
+#pagemenu{
+    -webkit-user-select: none; /* 适用于谷歌浏览器和Safari */ -moz-user-select: none; /* 适用于火狐浏览器 */ -ms-user-select: none; /* 适用于Internet Explorer/Edge */ user-select: none; /* 适用于支持CSS3的浏览器 */
+    position: fixed; /* 固定在页面上 */
+    top: 0px; /* 距离顶部距离 */
+    right: 0px; /* 距离右侧距离 */
+    z-index: 1000; /* 确保元素在最上层 */
+}
+
+#useravatar{
+    -webkit-user-select: none; /* 适用于谷歌浏览器和Safari */ -moz-user-select: none; /* 适用于火狐浏览器 */ -ms-user-select: none; /* 适用于Internet Explorer/Edge */ user-select: none; /* 适用于支持CSS3的浏览器 */
+    position: fixed; /* 固定在页面上 */
+    top: 0px; /* 距离顶部距离 */
+    right: 80px; /* 距离右侧距离 */
+    z-index: 1000; /* 确保元素在最上层 */
 }
 
 </style>

--- a/codesource-vue/src/components/HeadDisplay.vue
+++ b/codesource-vue/src/components/HeadDisplay.vue
@@ -1,13 +1,21 @@
 <template>
     <div id="Head">
-        <div id="projectName">
-            <h1>project name</h1>
-        </div>
+        <button id="projectName">
+            project name
+        </button>
+        <button id="pieChartButton">
+            <el-progress
+                type="circle"
+                :percentage="inlong"
+                :stroke-width="10"
+                :width="50"
+                :color="customColors"
+            />
+        </button>
         <Botton-list id="bottonlist"></Botton-list>
         <show-time></show-time>
-        <!-- 用于最顶上的进度条 -->
-        <progress-bar-main id="progress" :stroke-width="80" :Linelong="inlong" style="position: absolute; right: 325px; left: 700px; top:5px;"></progress-bar-main>
-       
+        <!-- 临时隐藏了原有的进度条 -->
+        <progress-bar-main v-if="false" id="progress" :stroke-width="80" :Linelong="inlong"></progress-bar-main>
     </div>
 </template>
 
@@ -17,11 +25,16 @@ import ShowTime from './HeaddisplayComponents/ShowTime.vue';
 import ProgressBarMain from './ProgressBarMain.vue';
 
 export default{
-
-
     data(){
         return{
-
+            // 自定义颜色，可以根据进度值动态设置
+            customColors: [
+                { color: '#f56c6c', percentage: 20 },
+                { color: '#e6a23c', percentage: 40 },
+                { color: '#5cb87a', percentage: 60 },
+                { color: '#1989fa', percentage: 80 },
+                { color: '#6f7ad3', percentage: 100 },
+            ],
         }
     },
     components:{
@@ -50,17 +63,89 @@ export default{
     right: 305px;
     height: 48px;
 }
-#progress{
-    -webkit-user-select: none; /* 适用于谷歌浏览器和Safari */ -moz-user-select: none; /* 适用于火狐浏览器 */ -ms-user-select: none; /* 适用于Internet Explorer/Edge */ user-select: none; /* 适用于支持CSS3的浏览器 */
 
+/* 饼状图样式 */
+#progress {
+    -webkit-user-select: none; /* 适用于谷歌浏览器和Safari */ -moz-user-select: none; /* 适用于火狐浏览器 */ -ms-user-select: none; /* 适用于Internet Explorer/Edge */ user-select: none; /* 适用于支持CSS3的浏览器 */
+    position: absolute;
+    top: 50%; 
+    transform: translateY(-50%); 
 }
+
+/* 饼状图按钮样式 */
+#pieChartButton {
+    -webkit-user-select: none; /* 适用于谷歌浏览器和Safari */
+    -moz-user-select: none; /* 适用于火狐浏览器 */
+    -ms-user-select: none; /* 适用于Internet Explorer/Edge */
+    user-select: none; /* 适用于支持CSS3的浏览器 */
+    position: fixed; 
+    top: 0px;
+    left: calc(65%); /* 紧挨着 projectName 右侧 */
+    text-align: center; 
+    height: 65px;
+    z-index: 1000; 
+
+    /* 按钮样式 */
+    color: #484848; 
+
+    cursor: pointer; /* 鼠标悬停时显示手型 */
+
+    /* 使按钮完全不可见 */
+    background-color: transparent; /* 背景透明 */
+    border: none; /* 移除边框 */
+    box-shadow: none; /* 移除阴影 */
+    outline: none; /* 移除点击时的轮廓 */
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+#pieChartButton:hover {
+    transform: translateY(2px); /* 悬浮时略微下凹 */
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* 悬浮时添加阴影 */
+}
+
+#pieChartButton:active {
+    transform: translateY(4px); /* 点击时进一步下凹 */
+    color: #303030; /* 点击时颜色加深 */
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); /* 点击时阴影变小 */
+}
+
+
 #projectName{
     -webkit-user-select: none; /* 适用于谷歌浏览器和Safari */ -moz-user-select: none; /* 适用于火狐浏览器 */ -ms-user-select: none; /* 适用于Internet Explorer/Edge */ user-select: none; /* 适用于支持CSS3的浏览器 */
+    position: fixed; /* 固定在页面上 */
+    top: 0px; 
+    left: 50%; /* 水平居中 */
+    transform: translateX(-50%); /* 通过偏移实现精确居中 */
+    text-align: center; /* 文本居中 */
+    width: 30%; /* 宽度根据内容自适应 */
+    height: 65px;
+    z-index: 1000; /* 确保元素在最上层 */
 
-    position: absolute;
-    top: -13px;
-    left: 420px;
-    color: #5e5e5e;
+    /* 按钮样式 */
+    padding: 10px 20px; /* 内边距 */
+    color: #484848; /* 文字颜色 */
+    font-size: 30px; /* 字体大小 */
+    font-weight: bold; /* 字体加粗 */
 
+    cursor: pointer; /* 鼠标悬停时显示手型 */
+
+    /* 使按钮完全不可见 */
+    background-color: transparent; /* 背景透明 */
+    border: none; /* 移除边框 */
+    box-shadow: none; /* 移除阴影 */
+    outline: none; /* 移除点击时的轮廓 */
+    transition: transform 0.2s ease, box-shadow 0.2s ease; /*缓动效果*/
 }
+
+#projectName:hover {
+    transform: translateX(-50%) translateY(2px); /* 悬浮时略微下凹 */
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* 悬浮时添加阴影 */
+}
+
+#projectName:active {
+    transform: translateX(-50%) translateY(4px); /* 点击时进一步下凹 */
+    color: #303030; /* 点击时颜色加深 */
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); /* 点击时阴影变小 */
+}
+
 </style>

--- a/codesource-vue/src/components/HeaddisplayComponents/PageMenu.vue
+++ b/codesource-vue/src/components/HeaddisplayComponents/PageMenu.vue
@@ -1,0 +1,46 @@
+<template>
+    <el-button class="menu-button">
+        <span class="icon">☰</span>
+    </el-button>
+</template>
+
+<script>
+export default {
+    data() {
+        return {};
+    },
+    methods: {}
+};
+</script>
+
+<style scoped>
+.menu-button {
+    width: 62px; /* 设置按钮宽度 */
+    height: 62px; /* 设置按钮高度 */
+    margin-bottom: 3px;
+    padding: 0; /* 去除内边距 */
+    background-color: transparent; /* 背景透明 */
+    border: none; /* 去除边框 */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer; /* 鼠标悬停时显示为手型 */
+    transition: transform 0.1s ease, box-shadow 0.1s ease; /*缓动效果*/
+}
+
+.menu-button:hover {
+    transform: translateY(2px); /* 悬浮时略微下凹 */
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1); /* 悬浮时添加阴影 */
+}
+
+.menu-button:active {
+    transform: translateY(4px); /* 点击时进一步下凹 */
+    color: #303030; /* 点击时颜色加深 */
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); /* 点击时阴影变小 */
+}
+
+.icon {
+    font-size: 45px; /* 设置图标大小 */
+    color: #606060; /* 设置图标颜色 */
+}
+</style>

--- a/codesource-vue/src/components/HeaddisplayComponents/ShowTime.vue
+++ b/codesource-vue/src/components/HeaddisplayComponents/ShowTime.vue
@@ -1,50 +1,45 @@
-<!-- 时间组件 -->
-
 <template>
-    <div id="backgrand"></div>
-    <div id="time">
-        <div id="now">
-            XX:XX
-        </div>
-        <div id="now_move">
-            :
-        </div>
-        <div id="yearmon">
-            no define
+    <div id="clock-container">
+        <!-- <div id="backgrand"></div> -->
+        <div id="time">
+            <div id="now">
+                XX:XX
+            </div>
+            <div id="now_move">
+                :
+            </div>
+            <div id="yearmon">
+                no define
+            </div>
         </div>
     </div>
-    
 </template>
 
 <script>
-export default{
-    data(){
-        return{
-
-        }
+export default {
+    data() {
+        return {};
     },
-    mounted(){
+    mounted() {
         setInterval(this.updateTime, 1000);
         this.updateTime();
     },
-    methods:{
-        updateTime(){
+    methods: {
+        updateTime() {
             const now = new Date();
             const hours = String(now.getHours()).padStart(2, '0');
             const minutes = String(now.getMinutes()).padStart(2, '0');
             const yesrs = String(now.getFullYear()).padStart(2, '0');
-            const Month = String(now.getMonth()).padStart(2, '0');
-            const day = String(now.getDay()).padStart(2, '0');
-            //const seconds = String(now.getSeconds()).padStart(2, '0');
+            const Month = String(now.getMonth() + 1).padStart(2, '0'); 
+            const day = String(now.getDate()).padStart(2, '0'); 
 
             document.getElementById('now').textContent = hours + " " + minutes;
-            //document.getElementById('seconds').textContent = seconds;
             document.getElementById('yearmon').textContent = yesrs + '/' + Month + '/' + day;
 
             const move = document.getElementById('now_move');
-            if(move.textContent == ':'){
+            if (move.textContent == ':') {
                 move.textContent = ' ';
-            }else{
+            } else {
                 move.textContent = ':';
             }
         }
@@ -53,7 +48,12 @@ export default{
 </script>
 
 <style scoped>
-#now{
+#clock-container {
+    transform: scale(0.8); /* 时钟的缩放比例 */
+    /* transform-origin: top left; 缩放的原点，默认是中心 */
+}
+
+#now {
     -webkit-user-select: none; /* 适用于谷歌浏览器和Safari */ -moz-user-select: none; /* 适用于火狐浏览器 */ -ms-user-select: none; /* 适用于Internet Explorer/Edge */ user-select: none; /* 适用于支持CSS3的浏览器 */
 
     width: 200px;
@@ -65,10 +65,10 @@ export default{
     color: #909090;
     font-weight: bold; /* 设置为粗体 */
 }
-#now_move{
+#now_move {
     -webkit-user-select: none; /* 适用于谷歌浏览器和Safari */ -moz-user-select: none; /* 适用于火狐浏览器 */ -ms-user-select: none; /* 适用于Internet Explorer/Edge */ user-select: none; /* 适用于支持CSS3的浏览器 */
 
-    width: 200px;
+    width: auto;
     height: 40px;
     font-size: 270%;
     position: absolute;
@@ -77,19 +77,19 @@ export default{
     color: #b1b1b1;
     font-weight: bold; /* 设置为粗体 */
 }
-#yearmon{
+#yearmon {
     -webkit-user-select: none; /* 适用于谷歌浏览器和Safari */ -moz-user-select: none; /* 适用于火狐浏览器 */ -ms-user-select: none; /* 适用于Internet Explorer/Edge */ user-select: none; /* 适用于支持CSS3的浏览器 */
 
-    width: 400px;
+    width: auto;
     height: 40px;
-    font-size: 170%;
+    font-size: 120%;
     position: absolute;
     left: 140px;
-    top: 12px;
+    top: 20px;
     color: #b1b1b1;
     font-weight: bold; /* 设置为粗体 */
 }
-#backgrand{
+#backgrand {
     width: 310px;
     height: 50px;
     background-color: #eeeeee;

--- a/codesource-vue/src/components/HeaddisplayComponents/UserAvatar.vue
+++ b/codesource-vue/src/components/HeaddisplayComponents/UserAvatar.vue
@@ -1,0 +1,44 @@
+<template>
+    <el-button class="user-button" circle>
+        <span class="icon">X</span>
+    </el-button>
+</template>
+
+<script>
+export default {
+    data() {
+        return {};
+    },
+    methods: {}
+};
+</script>
+
+<style scoped>
+.user-button {
+    width: 55px; /* 设置按钮宽度 */
+    height: 55px; /* 设置按钮高度 */
+    margin: 5px;
+    padding: 0; /* 去除内边距 */
+    background-color: #e9f5ff; /* 背景透明 */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer; /* 鼠标悬停时显示为手型 */
+    transition: transform 0.1s ease, box-shadow 0.1s ease; /*缓动效果*/
+}
+
+.user-button:hover {
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1); /* 悬浮时添加阴影 */
+}
+
+.user-button:active {
+    transform: translateY(2px); /* 悬浮时略微下凹 */
+    color: #303030; /* 点击时颜色加深 */
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); /* 点击时阴影变小 */
+}
+
+.icon {
+    font-size: 35px; /* 设置图标大小 */
+    color: #606060; /* 设置图标颜色 */
+}
+</style>


### PR DESCRIPTION
# 12月31日更改记录

## ShowTime.vue

1. 去除了时钟的灰色背景
2. 添加了clock-container来包裹时钟组件，可通过155行来修改其大小和缩放位置
3. 略调小了年月日，并把宽度改为auto



## HeadDisplay.vue

1. 略加深了projectName的颜色、加大了字号，改为居中
2. 去除了projectName的div和h1，改为button，宽度改为页面占比30%
3. _**后期需添加的限制：创建任务标题时字数不得超过x**_
4. 更改进度条为饼状，并且紧贴projectName右侧
5. 用button包裹了进度条，添加了随进度百分比更换颜色的功能
6. 优化了按钮的动画效果
7. 停用了原先的BottonList.vue，更改为PageMenu.vue和UserAvatar.vue

## app.vue

1. 略微缩短了el-header的高度（65px）



## PageMenu.vue（新增）

控制页面菜单按钮，点击可在右侧呼出菜单栏

主要内容有

> 返回主页，设置，快速新建任务，当前页面管理···

## UserAvatar.vue（新增）

显示头像，点击可向下呼出用户栏

主要内容有

> 登录登出，个人状态总览，其他用户总览，进入个人详细页面···